### PR TITLE
Minor change to man page for data(gapminder)

### DIFF
--- a/R/gapminder.R
+++ b/R/gapminder.R
@@ -10,7 +10,7 @@
 #'   \item{year}{ranges from 1952 to 2007 in increments of 5 years}
 #'   \item{lifeExp}{life expectancy at birth, in years}
 #'   \item{pop}{population}
-#'   \item{gdpPercap}{GDP per capita}
+#'   \item{gdpPercap}{GDP per capita (US$, inflation-adjusted)}
 #'   }
 #'   
 #' The supplemental data frame \code{\link{gapminder_unfiltered}} was not

--- a/man/gapminder.Rd
+++ b/man/gapminder.Rd
@@ -11,7 +11,7 @@
   \item{year}{ranges from 1952 to 2007 in increments of 5 years}
   \item{lifeExp}{life expectancy at birth, in years}
   \item{pop}{population}
-  \item{gdpPercap}{GDP per capita}
+  \item{gdpPercap}{GDP per capita (US$, inflation-adjusted)}
   }
   
 The supplemental data frame \code{\link{gapminder_unfiltered}} was not


### PR DESCRIPTION
Added units `(US$, inflation-adjusted)` to `gdpPercap` variable in `gapminder` data frame man page. My students were wondering what they were.