### PR TITLE
Lifecycle changes in ggplot2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     tibble
 Suggests:
     dplyr,
-    ggplot2,
+    ggplot2 (>= 3.0.0),
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/R/country_colors.R
+++ b/R/country_colors.R
@@ -52,7 +52,7 @@
 #'     subset(gapminder, continent != "Oceania"),
 #'     aes(x = year, y = lifeExp, group = country, color = country)
 #'   ) +
-#'     geom_line(lwd = 1, show_guide = FALSE) +
+#'     geom_line(lwd = 1, show.legend = FALSE) +
 #'     facet_wrap(~continent) +
 #'     scale_color_manual(values = country_colors) +
 #'     theme_bw() +
@@ -64,7 +64,7 @@
 #'   ggplot(gap_bit, aes(x = gdpPercap, y = lifeExp, size = pop)) +
 #'     scale_x_log10(limits = c(150, 115000)) +
 #'     ylim(c(16, 96)) +
-#'     geom_point(pch = 21, color = "grey20", show_guide = FALSE) +
+#'     geom_point(pch = 21, color = "grey20", show.legend = FALSE) +
 #'     scale_size_area(max_size = 40) +
 #'     facet_wrap(~continent) +
 #'     coord_fixed(ratio = 1 / 43) +

--- a/man/country_colors.Rd
+++ b/man/country_colors.Rd
@@ -61,7 +61,7 @@ if (require(ggplot2)) {
     subset(gapminder, continent != "Oceania"),
     aes(x = year, y = lifeExp, group = country, color = country)
   ) +
-    geom_line(lwd = 1, show_guide = FALSE) +
+    geom_line(lwd = 1, show.legend = FALSE) +
     facet_wrap(~continent) +
     scale_color_manual(values = country_colors) +
     theme_bw() +
@@ -73,7 +73,7 @@ if (require(ggplot2)) {
   ggplot(gap_bit, aes(x = gdpPercap, y = lifeExp, size = pop)) +
     scale_x_log10(limits = c(150, 115000)) +
     ylim(c(16, 96)) +
-    geom_point(pch = 21, color = "grey20", show_guide = FALSE) +
+    geom_point(pch = 21, color = "grey20", show.legend = FALSE) +
     scale_size_area(max_size = 40) +
     facet_wrap(~continent) +
     coord_fixed(ratio = 1 / 43) +


### PR DESCRIPTION
Hi Jenny,

In ggplot2 we're disallowing the `show_guide` argument, which has been deprecated since ggplot2 2.0.0.
This PR updates the examples to use the modern equivalent.
We plan to release mid June and it would be nice if we didn't break gapminder :)

Best wishes,
Teun